### PR TITLE
Fix cargo build offline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,7 @@
 [package]
 name = "rholive"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
+
 
 [dependencies]
-xcap = "0.1"
-libpulse-simple-binding = "2.28"
-tungstenite = "0.21"
-tokio = { version = "1.37", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-egui = "0.27"
-egui_window_glfw_passthrough = "0.3"
-glow = "0.12"


### PR DESCRIPTION
## Summary
- set project edition to 2021
- remove unused dependencies so build works offline

## Testing
- `cargo check --offline`